### PR TITLE
feat: Implement Memo List and Firestore Integration

### DIFF
--- a/shabelingo-mobile/app/create.tsx
+++ b/shabelingo-mobile/app/create.tsx
@@ -70,22 +70,26 @@ export default function CreateScreen() {
     }
   }
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!text && !audioUri && !imageUri) {
       Alert.alert('Empty Memo', 'Please add some content.');
       return;
     }
     
-    addMemo({
-      text: text || 'Audio Note',
-      category: selectedCategoryIds[0] || 'Uncategorized',
-      audioUrl: audioUri || undefined,
-      imageUrl: imageUri || undefined,
-      transcription: text,
-    });
+    try {
+      await addMemo({
+        originalText: text || 'Audio Note',
+        categoryIds: selectedCategoryIds,
+        audioUrl: audioUri || undefined,
+        imageUrl: imageUri || undefined,
+        transcription: text,
+      });
 
-    Alert.alert('Saved!', 'Your memo has been saved.');
-    router.back();
+      Alert.alert('Saved!', 'Your memo has been saved.');
+      router.back();
+    } catch (error) {
+      Alert.alert('Error', 'Failed to save memo.');
+    }
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
Closes #17
Closes #18

## 変更内容
- **MemoContextのFirestore化**: モックデータを廃止し、`subscribeMemos` でリアルタイム同期を実現。
- **データモデルの整備**: `types/index.ts` の定義（`originalText`, `categoryIds`）に合わせてアプリ全体を修正。
- **メモ作成機能の更新**: `app/create.tsx` からFirestoreへ保存できるように引数を変更。
- **一覧画面の更新**: `app/index.tsx` でFirestoreのデータを表示。カテゴリーIDからカテゴリー名を解決してバッジ表示する機能を追加。
- **Firestoreヘルパー追加**: `lib/firestore.ts` にメモ用CRUD処理を追加。

## 確認手順
1. ゲストログイン等でログインする。
2. 「New Memo」からメモを作成し、カテゴリーを選択して保存する。
3. 一覧画面に戻り、作成したメモが正しいカテゴリー名と共に表示されることを確認する。
