### PR TITLE
feat: Improve Category Selection and Display

### DIFF
--- a/shabelingo-mobile/components/ui/CategorySelector.tsx
+++ b/shabelingo-mobile/components/ui/CategorySelector.tsx
@@ -37,7 +37,12 @@ export function CategorySelector({ selectedCategoryIds, onSelect, multiSelect = 
         onSelect([...selectedCategoryIds, id]);
       }
     } else {
-      onSelect([id]);
+      // Single Select: Toggle if already selected
+      if (selectedCategoryIds.includes(id)) {
+        onSelect([]);
+      } else {
+        onSelect([id]);
+      }
     }
   };
 
@@ -52,8 +57,15 @@ export function CategorySelector({ selectedCategoryIds, onSelect, multiSelect = 
       return;
     }
     try {
-      await addCategory(user.uid, newCategoryName.trim());
+      const newId = await addCategory(user.uid, newCategoryName.trim());
       setIsAdding(false);
+      // Auto-select the new category
+      // 注意: handleSelectはstateを使うので、ここでは直接onSelectを呼んだほうが安全かもしれないが、handleSelectでもよい
+      if (multiSelect) {
+        onSelect([...selectedCategoryIds, newId]);
+      } else {
+        onSelect([newId]);
+      }
     } catch (error) {
       Alert.alert('Error', 'Failed to add category');
     }

--- a/shabelingo-mobile/lib/firestore.ts
+++ b/shabelingo-mobile/lib/firestore.ts
@@ -43,16 +43,14 @@ export const subscribeCategories = (userId: string, callback: (categories: Categ
  */
 export const addCategory = async (userId: string, name: string, color?: string) => {
   try {
-    // 同じ名前のカテゴリーがないかチェック（オプション）
-    // 今回は簡易実装のため重複チェックは省略またはUI側で行う
-
-    await addDoc(categoriesRef, {
+    const docRef = await addDoc(categoriesRef, {
       userId,
       name,
       color: color || '#9d4edd', // Default color
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
     });
+    return docRef.id;
   } catch (error) {
     console.error('Error adding category:', error);
     throw error;


### PR DESCRIPTION
## 変更内容
ユーザーフィードバックに基づき、カテゴリー選択と表示のUXを改善しました。

- **CategorySelector.tsx**: 
  - カテゴリー新規作成時に、作成したカテゴリーを自動的に選択状態にする機能を追加。
  - 選択済みのカテゴリーを再度タップすることで選択を解除（トグル）できる機能を追加。
- **firestore.ts**: 
  - `addCategory` が作成されたカテゴリーのIDを返すように修正。
- **index.tsx**:
  - `subscribeCategories` を導入し、メモ一覧表示時にカテゴリーIDを名前（name）に変換して表示するように修正。

## 補足
以前のAuth永続化の試みで発生した起動クラッシュを解決するため、ベースを安定版（main）に戻した上で、UI/UXの改善のみを適用しています。
現在のメモデータはモック（メモリ保持）ですが、カテゴリーはFirestoreと正しく連携しています。
