### PR TITLE
feat: Integrate Firestore for Memo Persistence

### DIFF
--- a/shabelingo-mobile/app/index.tsx
+++ b/shabelingo-mobile/app/index.tsx
@@ -56,13 +56,17 @@ export default function HomeScreen() {
           <Card style={styles.card}>
             <View style={styles.cardHeader}>
               <View style={styles.badge}>
-                <Text style={styles.badgeText}>{getCategoryName(item.category)}</Text>
+                {/* categoryIds配列の0番目を表示 */}
+                <Text style={styles.badgeText}>
+                  {getCategoryName(item.categoryIds && item.categoryIds.length > 0 ? item.categoryIds[0] : 'Uncategorized')}
+                </Text>
               </View>
               <Text style={styles.date}>
                 {new Date(item.createdAt).toLocaleDateString()}
               </Text>
             </View>
-            <Text style={styles.cardText}>{item.text}</Text>
+            {/* text ではなく originalText を表示 */}
+            <Text style={styles.cardText}>{item.originalText}</Text>
           </Card>
         )}
         ListEmptyComponent={


### PR DESCRIPTION
## 変更内容
メモ機能の実装をモックデータからFirestoreを使用した永続化データに切り替えました。
また、ユーザーインターフェースを新しいデータ構造（`originalText`, `categoryIds`）に適応させました。

### 主な変更点
- **lib/firestore.ts**:
  - `subscribeMemos`, `addMemo` 関数を追加し、FirestoreのCRUD操作を実装。
  - SRS（間隔反復学習）用の初期パラメータ設定ロジックを追加。
- **context/MemoContext.tsx**:
  - モックデータの使用を廃止し、`AuthContext` のユーザーIDに基づいてFirestoreデータを購読・操作するように変更。
  - `addMemo` の引数を新しいスキーマに合わせて変換。
- **app/index.tsx**:
  - メモリストの表示を修正し、`text` → `originalText`、`category` → `categoryIds[0]` (名前解決済み) を表示するように変更。

### 確認事項
- メモを作成し、Firestoreに保存されること。
- アプリをリロードしてもメモデータが保持されていること（データ永続化）。
- カテゴリー名が正しく表示されること。

※ Auth永続化（ログイン維持）は本PRには含まれず、次のステップで実装します。
