### PR TITLE
feat: Implement Firebase Storage Upload & Thumbnail Display

### DIFF
--- a/shabelingo-mobile/app/index.tsx
+++ b/shabelingo-mobile/app/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, FlatList, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, FlatList, SafeAreaView, Image } from 'react-native';
 import { Stack, useRouter } from 'expo-router';
 import { Plus, Play } from 'lucide-react-native';
 import { Colors, Layout } from '../constants/Colors';
@@ -54,19 +54,31 @@ export default function HomeScreen() {
         contentContainerStyle={styles.listContent}
         renderItem={({ item }) => (
           <Card style={styles.card}>
-            <View style={styles.cardHeader}>
-              <View style={styles.badge}>
-                {/* categoryIds配列の0番目を表示 */}
-                <Text style={styles.badgeText}>
-                  {getCategoryName(item.categoryIds && item.categoryIds.length > 0 ? item.categoryIds[0] : 'Uncategorized')}
-                </Text>
+            <View style={styles.cardContent}>
+              <View style={styles.cardMain}>
+                <View style={styles.cardHeader}>
+                  <View style={styles.badge}>
+                    {/* categoryIds配列の0番目を表示 */}
+                    <Text style={styles.badgeText}>
+                      {getCategoryName(item.categoryIds && item.categoryIds.length > 0 ? item.categoryIds[0] : 'Uncategorized')}
+                    </Text>
+                  </View>
+                  <Text style={styles.date}>
+                    {new Date(item.createdAt).toLocaleDateString()}
+                  </Text>
+                </View>
+                {/* text ではなく originalText を表示 */}
+                <Text style={styles.cardText} numberOfLines={3}>{item.originalText}</Text>
               </View>
-              <Text style={styles.date}>
-                {new Date(item.createdAt).toLocaleDateString()}
-              </Text>
+              
+              {item.imageUrl && (
+                <Image 
+                  source={{ uri: item.imageUrl }} 
+                  style={styles.cardThumbnail} 
+                  resizeMode="cover"
+                />
+              )}
             </View>
-            {/* text ではなく originalText を表示 */}
-            <Text style={styles.cardText}>{item.originalText}</Text>
           </Card>
         )}
         ListEmptyComponent={
@@ -101,7 +113,15 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   card: {
+    // Card自体パディングを持っているはずなので、ここでは内部レイアウトには関与しない
+  },
+  cardContent: {
+    flexDirection: 'row',
     gap: 12,
+  },
+  cardMain: {
+    flex: 1,
+    gap: 8,
   },
   cardHeader: {
     flexDirection: 'row',
@@ -130,6 +150,12 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '600',
     lineHeight: 28,
+  },
+  cardThumbnail: {
+    width: 80,
+    height: 80,
+    borderRadius: 8,
+    backgroundColor: '#eee',
   },
   empty: {
     padding: 32,

--- a/shabelingo-mobile/lib/storage.ts
+++ b/shabelingo-mobile/lib/storage.ts
@@ -1,0 +1,29 @@
+import { storage } from './firebase';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+
+/**
+ * Upload an image from a local URI to Firebase Storage.
+ * @param uri Local file URI (e.g. file://...)
+ * @param path Storage path (e.g. users/userId/images/filename)
+ * @returns Promise resolving to the download URL
+ */
+export const uploadImage = async (uri: string, path: string): Promise<string> => {
+  try {
+    // Convert URI to Blob
+    const response = await fetch(uri);
+    const blob = await response.blob();
+
+    // Create a reference
+    const storageRef = ref(storage, path);
+
+    // Upload
+    await uploadBytes(storageRef, blob);
+
+    // Get URL
+    const downloadURL = await getDownloadURL(storageRef);
+    return downloadURL;
+  } catch (error) {
+    console.error('Error uploading image:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## 変更内容
画像のクラウド保存と一覧表示の実装を行いました。

### 1. Firebase Storage連携 (Issue #37)
- `lib/storage.ts`: 画像をBlob変換してFirebase Storageにアップロードする機能を追加。
- `context/MemoContext.tsx`: メモ作成時に画像をアップロードし、取得したURLをFirestoreに保存するように変更。
- これにより、アプリを削除しても画像データが保持され、他端末からもアクセス可能になります。

### 2. UI改善 (Issue #38 関連)
- `app/index.tsx`: メモ一覧カードのレイアウトを変更し、右側に画像サムネイルを表示するようにしました。
- 画像サイズを適切に制限し、一覧性を向上させました。

## 確認方法
1. `New Memo` から画像付きのメモを作成。
2. 作成後、一覧画面にサムネイル付きでメモが表示されることを確認。
3. アプリをリロードしても画像が表示され続けることを確認。

Closes #37
Updates #38
