### PR TITLE
feat: Implement Memo Detail Screen

### DIFF
--- a/shabelingo-mobile/app/index.tsx
+++ b/shabelingo-mobile/app/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, FlatList, SafeAreaView, Image } from 'react-native';
+import { View, Text, StyleSheet, FlatList, SafeAreaView, Image, TouchableOpacity } from 'react-native';
 import { Stack, useRouter } from 'expo-router';
 import { Plus, Play } from 'lucide-react-native';
 import { Colors, Layout } from '../constants/Colors';
@@ -53,33 +53,35 @@ export default function HomeScreen() {
         keyExtractor={(item) => item.id}
         contentContainerStyle={styles.listContent}
         renderItem={({ item }) => (
-          <Card style={styles.card}>
-            <View style={styles.cardContent}>
-              <View style={styles.cardMain}>
-                <View style={styles.cardHeader}>
-                  <View style={styles.badge}>
-                    {/* categoryIds配列の0番目を表示 */}
-                    <Text style={styles.badgeText}>
-                      {getCategoryName(item.categoryIds && item.categoryIds.length > 0 ? item.categoryIds[0] : 'Uncategorized')}
+          <TouchableOpacity onPress={() => router.push(`/memo/${item.id}`)} activeOpacity={0.9}>
+            <Card style={styles.card}>
+              <View style={styles.cardContent}>
+                <View style={styles.cardMain}>
+                  <View style={styles.cardHeader}>
+                    <View style={styles.badge}>
+                      {/* categoryIds配列の0番目を表示 */}
+                      <Text style={styles.badgeText}>
+                        {getCategoryName(item.categoryIds && item.categoryIds.length > 0 ? item.categoryIds[0] : 'Uncategorized')}
+                      </Text>
+                    </View>
+                    <Text style={styles.date}>
+                      {new Date(item.createdAt).toLocaleDateString()}
                     </Text>
                   </View>
-                  <Text style={styles.date}>
-                    {new Date(item.createdAt).toLocaleDateString()}
-                  </Text>
+                  {/* text ではなく originalText を表示 */}
+                  <Text style={styles.cardText} numberOfLines={3}>{item.originalText}</Text>
                 </View>
-                {/* text ではなく originalText を表示 */}
-                <Text style={styles.cardText} numberOfLines={3}>{item.originalText}</Text>
+                
+                {item.imageUrl && (
+                  <Image 
+                    source={{ uri: item.imageUrl }} 
+                    style={styles.cardThumbnail} 
+                    resizeMode="cover"
+                  />
+                )}
               </View>
-              
-              {item.imageUrl && (
-                <Image 
-                  source={{ uri: item.imageUrl }} 
-                  style={styles.cardThumbnail} 
-                  resizeMode="cover"
-                />
-              )}
-            </View>
-          </Card>
+            </Card>
+          </TouchableOpacity>
         )}
         ListEmptyComponent={
           <View style={styles.empty}>

--- a/shabelingo-mobile/app/memo/[id].tsx
+++ b/shabelingo-mobile/app/memo/[id].tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Image, ScrollView, SafeAreaView, ActivityIndicator } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { Play } from 'lucide-react-native';
+import { Colors, Layout } from '../../constants/Colors';
+import { Button } from '../../components/ui/Button';
+import { useMemoContext } from '../../context/MemoContext';
+import { useAuth } from '../../context/AuthContext';
+import { subscribeCategories } from '../../lib/firestore';
+import { Category, Memo } from '../../types';
+
+export default function MemoDetailScreen() {
+  const { id } = useLocalSearchParams();
+  const router = useRouter();
+  const { user } = useAuth();
+  const { memos } = useMemoContext();
+  const [memo, setMemo] = useState<Memo | undefined>(undefined);
+  const [categories, setCategories] = useState<Record<string, Category>>({});
+
+  useEffect(() => {
+    if (memos.length > 0 && id) {
+      const found = memos.find(m => m.id === id);
+      setMemo(found);
+    }
+  }, [memos, id]);
+
+  useEffect(() => {
+    if (!user) return;
+    const unsubscribe = subscribeCategories(user.uid, (list) => {
+      const map = list.reduce((acc, cat) => ({ ...acc, [cat.id]: cat }), {});
+      setCategories(map);
+    });
+    return () => unsubscribe();
+  }, [user]);
+
+  const getCategoryName = (idOrName: string) => {
+    const cat = categories[idOrName];
+    return cat ? cat.name : idOrName;
+  };
+
+  if (!memo) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loading}>
+            <ActivityIndicator size="large" color={Colors.primary} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Stack.Screen options={{ headerTitle: 'Memo Detail', headerBackTitle: 'Back' }} />
+      
+      <ScrollView contentContainerStyle={styles.content}>
+        {/* Header Info */}
+        <View style={styles.header}>
+            <View style={styles.badge}>
+                <Text style={styles.badgeText}>
+                    {getCategoryName(memo.categoryIds && memo.categoryIds.length > 0 ? memo.categoryIds[0] : 'Uncategorized')}
+                </Text>
+            </View>
+            <Text style={styles.date}>
+                {new Date(memo.createdAt).toLocaleDateString()} {new Date(memo.createdAt).toLocaleTimeString()}
+            </Text>
+        </View>
+
+        {/* Main Text */}
+        <Text style={styles.originalText}>{memo.originalText}</Text>
+
+        {/* Image */}
+        {memo.imageUrl && (
+            <Image 
+                source={{ uri: memo.imageUrl }} 
+                style={styles.image} 
+                resizeMode="contain"
+            />
+        )}
+
+        {/* Audio Player Placeholder */}
+        {memo.audioUrl && (
+            <View style={styles.audioContainer}>
+                <Button 
+                    variant="secondary"
+                    icon={<Play size={20} color="#000" />}
+                    title="Play Audio"
+                    onPress={() => console.log('Play audio TODO')}
+                    style={styles.audioButton}
+                />
+            </View>
+        )}
+
+        {/* Notes / Transcription */}
+        {memo.note && (
+            <View style={styles.noteContainer}>
+                <Text style={styles.noteLabel}>Note / Transcription</Text>
+                <Text style={styles.noteText}>{memo.note}</Text>
+            </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  loading: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    padding: Layout.padding,
+    gap: 24,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  badge: {
+    backgroundColor: 'rgba(157, 78, 221, 0.2)',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+  },
+  badgeText: {
+    color: Colors.primary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  date: {
+    color: Colors.mutedForeground,
+    fontSize: 14,
+  },
+  originalText: {
+    color: Colors.foreground,
+    fontSize: 24,
+    fontWeight: 'bold',
+    lineHeight: 34,
+  },
+  image: {
+    width: '100%',
+    height: 300,
+    borderRadius: 12,
+    backgroundColor: '#eee',
+  },
+  audioContainer: {
+    flexDirection: 'row',
+  },
+  audioButton: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#e5e5e5',
+  },
+  noteContainer: {
+    backgroundColor: '#f9f9f9',
+    padding: 16,
+    borderRadius: 12,
+    gap: 8,
+  },
+  noteLabel: {
+    color: Colors.mutedForeground,
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  noteText: {
+    color: Colors.foreground,
+    fontSize: 16,
+    lineHeight: 24,
+  },
+});


### PR DESCRIPTION
## 変更内容
メモ詳細画面を実装し、一覧からの遷移を可能にしました。また、詳細画面で画像や全テキストを確認できるようにしました。

### 1. 詳細画面実装 (Issue #38)
- `app/memo/[id].tsx`: メモIDを受け取り、Firestoreのデータから詳細を表示。
- 画像がある場合はフルサイズに近い形で表示。
- 音声再生ボタン（プレースホルダー）とNote（書き起こし/メモ）表示エリアを追加。

### 2. ナビゲーション
- `app/index.tsx`: カードコンポーネントを `TouchableOpacity` でラップし、タップ時に詳細画面へ遷移するように修正。

## 確認方法
1. メモ一覧で任意のメモをタップ。
2. 詳細画面に遷移し、内容（テキスト、画像、日時、カテゴリー）が正しく表示されることを確認。
3. `Back` ボタンで一覧に戻れることを確認。

Closes #38
