### PR TITLE
UI日本語化と復習ロジックの修正

### DIFF
--- a/shabelingo-mobile/app/create.tsx
+++ b/shabelingo-mobile/app/create.tsx
@@ -109,7 +109,7 @@ export default function CreateMemoScreen() {
     try {
       const perm = await requestRecordingPermissionsAsync();
       if (perm.status !== 'granted') {
-          Alert.alert("Permission Required", "Please grant microphone permission to record audio.");
+          Alert.alert("権限が必要です", "録音するにはマイクの使用許可が必要です。");
           return;
       }
       
@@ -122,7 +122,7 @@ export default function CreateMemoScreen() {
       recorder.record();
     } catch (err) {
       console.error('Failed to start recording', err);
-      Alert.alert("Error", "Failed to start recording.");
+      Alert.alert("エラー", "録音の開始に失敗しました。");
     }
   };
 
@@ -139,11 +139,11 @@ export default function CreateMemoScreen() {
 
   const handleSave = async () => {
     if (!text.trim()) {
-      alert('Please enter text');
+      alert('テキストを入力してください');
       return;
     }
     if (!selectedCategoryId) {
-      alert('Please select a category');
+      alert('カテゴリーを選択してください');
       return;
     }
 
@@ -159,7 +159,7 @@ export default function CreateMemoScreen() {
       });
       router.back();
     } catch (e: any) {
-      alert('Failed to save memo: ' + e.message);
+      alert('メモの保存に失敗しました: ' + e.message);
     }
   };
 
@@ -171,19 +171,19 @@ export default function CreateMemoScreen() {
         // CategorySelector will handle selection visually, but we might need to update local state logic if needed
         return newId;
     } catch (e) {
-        Alert.alert("Error", "Failed to add category");
+        Alert.alert("エラー", "カテゴリーの追加に失敗しました");
         throw e;
     }
   };
 
   return (
     <SafeAreaView style={styles.container}>
-      <Stack.Screen options={{ headerTitle: 'New Memo', headerBackTitle: 'Cancel' }} />
+      <Stack.Screen options={{ headerTitle: '新規メモ作成', headerBackTitle: 'キャンセル' }} />
       
       <ScrollView contentContainerStyle={styles.content}>
         {/* Language Selection */}
         <View style={styles.section}>
-          <Text style={styles.label}>Language</Text>
+          <Text style={styles.label}>言語</Text>
           <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 8 }}>
             {LANGUAGES.map((lang) => (
               <TouchableOpacity
@@ -206,10 +206,10 @@ export default function CreateMemoScreen() {
 
         {/* Text Input */}
         <View style={styles.section}>
-          <Text style={styles.label}>Word / Phrase</Text>
+          <Text style={styles.label}>学習したい言葉</Text>
           <TextInput
             style={styles.input}
-            placeholder="e.g., Hello"
+            placeholder="例: はろー"
             value={text}
             onChangeText={setText}
             autoFocus
@@ -218,11 +218,11 @@ export default function CreateMemoScreen() {
 
         {/* Evaluation Text Input */}
         <View style={styles.section}>
-          <Text style={styles.label}>Pronunciation Target (Optional)</Text>
-          <Text style={styles.hint}>If Word/Phrase is in Katakana, enter correct spelling here.</Text>
+          <Text style={styles.label}>発音評価用ターゲット (任意)</Text>
+          <Text style={styles.hint}>正しいスペルを入力してください</Text>
           <TextInput
             style={styles.input}
-            placeholder="e.g., Hello"
+            placeholder="例: Hello"
             value={evaluationText}
             onChangeText={setEvaluationText}
           />
@@ -230,7 +230,7 @@ export default function CreateMemoScreen() {
 
         {/* Category */}
         <View style={styles.section}>
-          <Text style={styles.label}>Category</Text>
+          <Text style={styles.label}>カテゴリー</Text>
           <CategorySelector
             selectedCategoryIds={selectedCategoryId ? [selectedCategoryId] : []}
             onSelect={(ids) => setSelectedCategoryId(ids[0] || '')}
@@ -242,7 +242,7 @@ export default function CreateMemoScreen() {
         <View style={styles.rowSection}>
             {/* Image Picker */}
             <View style={styles.mediaCol}>
-                <Text style={styles.label}>Image</Text>
+                <Text style={styles.label}>画像</Text>
                 <TouchableOpacity onPress={handlePickImage} style={styles.imagePlaceholder}>
                     {imageUri ? (
                         <Image source={{ uri: imageUri }} style={styles.imagePreview} />
@@ -254,7 +254,7 @@ export default function CreateMemoScreen() {
                     <Button 
                         variant="ghost" 
                         size="sm" 
-                        title="Remove" 
+                        title="削除" 
                         onPress={() => setImageUri(undefined)}
                         style={{ marginTop: 8 }}
                     />
@@ -263,7 +263,7 @@ export default function CreateMemoScreen() {
 
             {/* Audio Recorder */}
             <View style={styles.mediaCol}>
-                <Text style={styles.label}>Voice Memo</Text>
+                <Text style={styles.label}>音声メモ</Text>
                 <View style={styles.audioControl}>
                     {recorderState.isRecording ? (
                          <TouchableOpacity onPress={stopRecording} style={[styles.recordBtn, styles.recording]}>
@@ -276,13 +276,13 @@ export default function CreateMemoScreen() {
                     )}
                 </View>
                 <Text style={styles.audioLabel}>
-                    {recorderState.isRecording ? "Recording..." : audioUri ? "Recorded!" : "Tap to Record"}
+                    {recorderState.isRecording ? "録音中..." : audioUri ? "録音完了!" : "タップして録音"}
                 </Text>
                  {audioUri && !recorderState.isRecording && (
                     <Button 
                         variant="ghost" 
                         size="sm" 
-                        title="Delete" 
+                        title="削除" 
                         onPress={() => setAudioUri(undefined)}
                         style={{ marginTop: 8 }}
                     />
@@ -292,10 +292,10 @@ export default function CreateMemoScreen() {
 
         {/* Notes */}
         <View style={styles.section}>
-          <Text style={styles.label}>Notes / Meaning</Text>
+          <Text style={styles.label}>意味・メモ</Text>
           <TextInput
             style={[styles.input, styles.textArea]}
-            placeholder="Translation, notes, etc."
+            placeholder="翻訳やメモなど"
             value={transcription}
             onChangeText={setTranscription}
             multiline
@@ -306,7 +306,7 @@ export default function CreateMemoScreen() {
         <Button
           variant="primary"
           size="lg"
-          title={loading ? "Saving..." : "Save Memo"}
+          title={loading ? "保存中..." : "保存"}
           onPress={handleSave}
           disabled={loading}
           style={styles.saveBtn}

--- a/shabelingo-mobile/app/index.tsx
+++ b/shabelingo-mobile/app/index.tsx
@@ -23,7 +23,7 @@ export default function HomeScreen() {
 
   // Filtering Logic
   const filteredMemos = memos.filter(m => {
-    const langMatch = filterLang === 'all' || m.language === filterLang || (!m.language && filterLang === 'all');
+    const langMatch = filterLang === 'all' ? true : m.language === filterLang;
     const catMatch = filterCat === 'all' || (m.categoryIds && m.categoryIds.includes(filterCat));
     return langMatch && catMatch;
   });

--- a/shabelingo-mobile/app/memo/[id].tsx
+++ b/shabelingo-mobile/app/memo/[id].tsx
@@ -75,19 +75,19 @@ export default function MemoDetailScreen() {
     if (!memo) return;
     
     Alert.alert(
-      "Delete Memo",
-      "Are you sure you want to delete this memo?",
+      "メモを削除",
+      "本当にこのメモを削除しますか？",
       [
-        { text: "Cancel", style: "cancel" },
+        { text: "キャンセル", style: "cancel" },
         { 
-          text: "Delete", 
+          text: "削除", 
           style: "destructive",
           onPress: async () => {
             try {
               await deleteMemo(memo.id);
               router.back();
             } catch (error) {
-              Alert.alert("Error", "Failed to delete memo");
+              Alert.alert("エラー", "メモの削除に失敗しました");
             }
           }
         }
@@ -110,10 +110,13 @@ export default function MemoDetailScreen() {
     <SafeAreaView style={styles.container}>
       <Stack.Screen 
         options={{ 
-          headerTitle: 'Memo Detail', 
-          headerBackTitle: 'Back',
+          headerTitle: 'メモ詳細', 
+          headerBackTitle: '戻る',
           headerRight: () => (
-            <TouchableOpacity onPress={handleDelete}>
+            <TouchableOpacity 
+              onPress={handleDelete} 
+              style={{ width: 44, height: 44, justifyContent: 'center', alignItems: 'center', marginTop: -4 }}
+            >
               <Trash2 size={24} color={Colors.destructive} />
             </TouchableOpacity>
           )
@@ -126,7 +129,7 @@ export default function MemoDetailScreen() {
             <View style={{ gap: 8, flexDirection: 'row', flexWrap: 'wrap' }}>
                 <View style={styles.badge}>
                     <Text style={styles.badgeText}>
-                        {getCategoryName(memo.categoryIds && memo.categoryIds.length > 0 ? memo.categoryIds[0] : 'Uncategorized')}
+                        {getCategoryName(memo.categoryIds && memo.categoryIds.length > 0 ? memo.categoryIds[0] : '未分類')}
                     </Text>
                 </View>
                 <View style={[styles.badge, { backgroundColor: '#f0f0f0' }]}>
@@ -158,7 +161,7 @@ export default function MemoDetailScreen() {
                 <Button 
                     variant={playerStatus.playing ? "destructive" : "secondary"}
                     icon={playerStatus.playing ? <Square size={20} color="#fff" /> : <Play size={20} color="#000" />}
-                    title={playerStatus.playing ? "Pause Audio" : "Play Audio"}
+                    title={playerStatus.playing ? "一時停止" : "再生"}
                     onPress={playSound}
                     style={styles.audioButton}
                 />
@@ -168,7 +171,7 @@ export default function MemoDetailScreen() {
         {/* Notes / Transcription */}
         {memo.note && (
             <View style={styles.noteContainer}>
-                <Text style={styles.noteLabel}>Note / Transcription</Text>
+                <Text style={styles.noteLabel}>メモ・翻訳</Text>
                 <Text style={styles.noteText}>{memo.note}</Text>
             </View>
         )}
@@ -245,7 +248,7 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   noteText: {
-    color: Colors.foreground,
+    color: '#000',
     fontSize: 16,
     lineHeight: 24,
   },


### PR DESCRIPTION
## 変更内容

### 🐛 バグ修正
- ホーム画面のTypeScript型エラー修正 ('SupportedLanguage'と'all'の比較ロジック修正)
- メモ詳細画面の視認性向上: 背景色が白の場合の文字色 (`noteText`) を黒に固定
- メモ詳細画面の音声再生音量問題を修正 (スピーカー出力に設定)

### 🌍 日本語化
- メモ作成画面 (CreateMemo) のUIテキストを日本語化
- メモ詳細画面 (MemoDetail) のUIテキストを日本語化

### ✨ 機能改善
- 復習画面の出題ロジック変更: 発音評価ターゲット (`evaluationText`) が設定されているメモのみを出題するようにフィルタリング
- メモ詳細画面の音声プレイヤーUIを刷新 (カード形式、波形ビジュアライザー追加)

### 🎨 デザイン大幅刷新 (Duolingo風テーマ)
- **カラーテーマ全体を明るく親しみやすいデザインに変更**
  - 背景: 黒 (#0a0a0f) → 明るいグレー (#f7f7f7)
  - プライマリカラー: 紫 (#9d4edd) → Duolingoグリーン (#58cc02)
  - セカンダリカラー: シアン (#00b4d8) → 明るいブルー (#1cb0f6)
  - アクセントカラー: マゼンタ (#ff006e) → オレンジ (#ff9600)
  - テキスト: 白 → ダークグレー (#3c3c3c)
  - カード: ダークグレー → 純白 (#ffffff)

- **UI要素の調整**
  - 角丸を増加 (16px → 20px) で柔らかい印象に
  - ヘッダーボタン: ダークグレー → 白カード + 微細な影
  - バッジ: 紫系 → 緑系に統一
  - カードコンポーネント: BlurViewの暗いぼかし効果を削除し、クリーンな白カードに変更
  - ステータスバー: ライトモード → ダークモード (明るい背景に対応)
  - メモ詳細画面の削除ボタンを中央揃えに調整

### 📱 スタイル調整
- 全画面でハードコードされた色をテーマカラーに置き換え
- シャドウとエレベーションを追加して奥行き感を向上
- アイコンの色を新しいテーマに合わせて調整