### PR TITLE
[UI/ロジック] メモ作成機能の改善: 意味・音訳の追加

### DIFF
--- a/shabelingo-mobile/app/memo/[id].tsx
+++ b/shabelingo-mobile/app/memo/[id].tsx
@@ -162,8 +162,27 @@ export default function MemoDetailScreen() {
             </Text>
         </View>
 
-        {/* Main Text */}
-        <Text style={styles.originalText}>{memo.originalText}</Text>
+        {/* Main Text (Romanized/Learning Word) */}
+        <View>
+          <Text style={styles.label}>学習したい言葉</Text>
+          <Text style={styles.originalText}>{memo.originalText}</Text>
+        </View>
+
+        {/* Evaluation Text (Native Script) */}
+        {memo.evaluationText && (
+          <View>
+            <Text style={styles.label}>発音評価用ターゲット</Text>
+            <Text style={styles.nativeText}>{memo.evaluationText}</Text>
+          </View>
+        )}
+
+        {/* Meaning (Japanese) */}
+        {memo.meaning && (
+          <View style={styles.noteContainer}>
+              <Text style={styles.noteLabel}>意味・メモ</Text>
+              <Text style={styles.noteText}>{memo.meaning}</Text>
+          </View>
+        )}
 
         {/* Image */}
         {memo.imageUrl && (
@@ -204,10 +223,10 @@ export default function MemoDetailScreen() {
             </View>
         )}
 
-        {/* Notes / Transcription */}
-        {memo.note && (
+        {/* Notes / Transcription (Legacy) */}
+        {memo.note && !memo.meaning && (
             <View style={styles.noteContainer}>
-                <Text style={styles.noteLabel}>メモ・翻訳</Text>
+                <Text style={styles.noteLabel}>メモ・翻訳(旧)</Text>
                 <Text style={styles.noteText}>{memo.note}</Text>
             </View>
         )}
@@ -334,5 +353,17 @@ const styles = StyleSheet.create({
     color: '#000',
     fontSize: 16,
     lineHeight: 24,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.mutedForeground,
+    marginBottom: 4,
+  },
+  nativeText: {
+    fontSize: 20,
+    color: Colors.foreground,
+    lineHeight: 28,
+    fontWeight: '500', 
   },
 });

--- a/shabelingo-mobile/context/MemoContext.tsx
+++ b/shabelingo-mobile/context/MemoContext.tsx
@@ -13,6 +13,7 @@ interface MemoContextType {
     transcription?: string;
     language?: SupportedLanguage;
     evaluationText?: string;
+    meaning?: string;
   }) => Promise<void>;
   deleteMemo: (id: string) => Promise<void>;
   loading: boolean;
@@ -49,6 +50,7 @@ export const MemoProvider: React.FC<{ children: React.ReactNode }> = ({ children
     transcription?: string;
     language?: SupportedLanguage;
     evaluationText?: string;
+    meaning?: string;
   }) => {
     if (!user) return;
 
@@ -85,6 +87,7 @@ export const MemoProvider: React.FC<{ children: React.ReactNode }> = ({ children
       note: memoData.transcription,
       language: memoData.language || 'en-US',
       evaluationText: memoData.evaluationText,
+      meaning: memoData.meaning,
     });
   };
 

--- a/shabelingo-mobile/lib/firestore.ts
+++ b/shabelingo-mobile/lib/firestore.ts
@@ -107,6 +107,7 @@ export const addMemo = async (userId: string, data: {
   note?: string;
   language?: SupportedLanguage;
   evaluationText?: string;
+  meaning?: string;
 }) => {
   try {
     // Remove undefined fields
@@ -130,6 +131,7 @@ export const addMemo = async (userId: string, data: {
     if (data.note !== undefined) cleanData.note = data.note;
     if (data.language !== undefined) cleanData.language = data.language;
     if (data.evaluationText !== undefined) cleanData.evaluationText = data.evaluationText;
+    if (data.meaning !== undefined) cleanData.meaning = data.meaning;
 
     await addDoc(memosRef, cleanData);
   } catch (error) {

--- a/shabelingo-mobile/lib/translator.ts
+++ b/shabelingo-mobile/lib/translator.ts
@@ -1,0 +1,169 @@
+import { SupportedLanguage } from '../types';
+
+const TRANSLATOR_ENDPOINT = 'https://api.cognitive.microsofttranslator.com';
+const TRANSLATOR_KEY = process.env.EXPO_PUBLIC_AZURE_TRANSLATOR_KEY || '';
+const TRANSLATOR_REGION = process.env.EXPO_PUBLIC_AZURE_TRANSLATOR_REGION || 'japaneast';
+
+/**
+ * Azure Translator APIを使用してテキストを翻訳
+ * @param text 翻訳するテキスト
+ * @param targetLanguage 翻訳先の言語コード
+ * @param sourceLanguage 翻訳元の言語コード（デフォルト: ja）
+ * @returns 翻訳されたテキスト
+ */
+export async function translateText(
+  text: string,
+  targetLanguage: SupportedLanguage,
+  sourceLanguage: string = 'ja'
+): Promise<string | null> {
+  if (!TRANSLATOR_KEY) {
+    console.error('Azure Translator API key is not set');
+    return null;
+  }
+
+  if (!text.trim()) {
+    return null;
+  }
+
+  try {
+    // Azure Translator APIは言語コードの形式が異なる場合がある
+    // 例: ko-KR -> ko, zh-CN -> zh-Hans
+    const targetLang = convertToTranslatorLanguageCode(targetLanguage);
+    
+    const url = `${TRANSLATOR_ENDPOINT}/translate?api-version=3.0&from=${sourceLanguage}&to=${targetLang}`;
+    
+    const headers: Record<string, string> = {
+      'Ocp-Apim-Subscription-Key': TRANSLATOR_KEY,
+      'Content-Type': 'application/json',
+    };
+
+    if (TRANSLATOR_REGION && TRANSLATOR_REGION !== 'global') {
+        headers['Ocp-Apim-Subscription-Region'] = TRANSLATOR_REGION;
+    }
+    
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify([{ text }]),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      if (response.status === 401) {
+        console.error('Translation API authentication failed. Please check your Azure Translator API key and region in .env file.');
+        console.error('Current key:', TRANSLATOR_KEY ? `${TRANSLATOR_KEY.substring(0, 10)}...` : 'NOT SET');
+        console.error('Current region:', TRANSLATOR_REGION);
+      }
+      console.error('Translation API error:', response.status, errorText);
+      return null;
+    }
+
+    const data = await response.json();
+    
+    if (data && data.length > 0 && data[0].translations && data[0].translations.length > 0) {
+      return data[0].translations[0].text;
+    }
+
+    return null;
+  } catch (error) {
+    console.error('Translation error:', error);
+    return null;
+  }
+}
+
+/**
+ * SupportedLanguageをAzure Translator APIの言語コードに変換
+ */
+function convertToTranslatorLanguageCode(language: SupportedLanguage): string {
+  const mapping: Record<string, string> = {
+    'en-US': 'en',
+    'en-GB': 'en',
+    'en-AU': 'en',
+    'zh-CN': 'zh-Hans',
+    'zh-TW': 'zh-Hant',
+    'es-ES': 'es',
+    'es-MX': 'es',
+    'fr-FR': 'fr',
+    'fr-CA': 'fr',
+    'de-DE': 'de',
+    'it-IT': 'it',
+    'ja-JP': 'ja',
+    'ko-KR': 'ko',
+    'pt-BR': 'pt',
+    'pt-PT': 'pt',
+    'ru-RU': 'ru',
+    'ar-SA': 'ar',
+    'hi-IN': 'hi',
+    'th-TH': 'th',
+    'vi-VN': 'vi',
+    'id-ID': 'id',
+    'tr-TR': 'tr',
+    'pl-PL': 'pl',
+    'nl-NL': 'nl',
+    'sv-SE': 'sv',
+    'fil-PH': 'fil',
+  };
+
+  return mapping[language] || language.split('-')[0];
+}
+
+/**
+ * テキストをローマ字に音訳する
+ */
+export async function getRomanization(text: string, language: SupportedLanguage): Promise<string | null> {
+  if (!text.trim()) return null;
+
+  const langCode = convertToTranslatorLanguageCode(language);
+  const script = getScriptCode(langCode);
+  
+  // スクリプトコードがない（ラテン文字など）場合は音訳不要
+  if (!script) return null;
+
+  try {
+    const url = `${TRANSLATOR_ENDPOINT}/transliterate?api-version=3.0&language=${langCode}&fromScript=${script}&toScript=Latn`;
+    
+    const headers: Record<string, string> = {
+      'Ocp-Apim-Subscription-Key': TRANSLATOR_KEY,
+      'Content-Type': 'application/json',
+    };
+
+    if (TRANSLATOR_REGION && TRANSLATOR_REGION !== 'global') {
+        headers['Ocp-Apim-Subscription-Region'] = TRANSLATOR_REGION;
+    }
+    
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify([{ text }]),
+    });
+
+    if (!response.ok) {
+      console.error('Transliteration API error:', response.status);
+      return null;
+    }
+
+    const data = await response.json();
+    if (data && data.length > 0 && data[0].text) {
+      return data[0].text;
+    }
+    return null;
+  } catch (error) {
+    console.error('Transliteration error:', error);
+    return null;
+  }
+}
+
+function getScriptCode(langCode: string): string | null {
+  const map: Record<string, string> = {
+    'ja': 'Jpan',
+    'ko': 'Kore',
+    'zh-Hans': 'Hans',
+    'zh-Hant': 'Hant',
+    'th': 'Thai',
+    'ar': 'Arab',
+    'hi': 'Deva', // Devanagari
+    'ru': 'Cyrl', // Cyrillic
+    // Add others if needed
+  };
+  return map[langCode] || null;
+}

--- a/shabelingo-mobile/types/index.ts
+++ b/shabelingo-mobile/types/index.ts
@@ -73,7 +73,8 @@ export interface Memo {
   
   // 言語 (New)
   language?: SupportedLanguage;
-  evaluationText?: string; // 発音評価用の正しいスペル (例: original="はろー", evaluation="Hello")
+  evaluationText?: string; // 発音評価用の正しいスペル (例: original="annyeonghaseyo", evaluation="안녕하세요")
+  meaning?: string;        // 日本語の意味 (例: "こんにちは")
 
   // 分類
   categoryIds: string[];   // 複数のカテゴリーに属せるように配列


### PR DESCRIPTION
**概要**:
ユーザーからのフィードバックに基づき、メモ作成時のフィールドを改善しました。

**変更点**:
- `Memo`型に`meaning`（意味・メモ）フィールドを追加し、日本語の意味を分けて保存するようにしました。
- 録音時に非ラテン文字言語（韓国語、中国語など）の場合、Azure Translatorの音訳機能を使用してローマ字（発音）を取得し、「学習したい言葉」フィールドに自動入力するようにしました。
- 音訳に失敗した場合やサポートされていない言語の場合は、プレースホルダーを表示して手動入力を促すようにしました。
- メモ詳細画面に「発音評価用ターゲット」と「意味・メモ」を表示するようにしました。
- 重複していたメモ入力欄を削除しました。

**解決した課題**:
- 「学習したい言葉」に現地の言葉が入ってしまう問題 (修正: ローマ字またはプレースホルダーが入る)
- 意味の入力欄が重複している問題 (修正: 削除)
- 意味が入力されない問題 (修正: 翻訳エラー時のフォールバック改善)
