### PR TITLE
fix(ui): コレクション画面のヘッダー統一とレイアウト修正

### DIFF
--- a/shabelingo-mobile/app/_layout.tsx
+++ b/shabelingo-mobile/app/_layout.tsx
@@ -1,40 +1,40 @@
+import { Colors } from '../constants/Colors';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { View } from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
-
-import { MemoProvider } from '../context/MemoContext';
 import { AuthProvider } from '../context/AuthContext';
-
-import { Colors } from '../constants/Colors';
+import { MemoProvider } from '../context/MemoContext';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { View } from 'react-native';
 
 export default function RootLayout() {
   return (
-    <SafeAreaProvider>
-      <AuthProvider>
-        <MemoProvider>
-          <StatusBar style="dark" />
-          <Stack
-            screenOptions={{
-              headerStyle: {
-                backgroundColor: Colors.background,
-              },
-              headerTintColor: Colors.foreground,
-              headerTitleStyle: {
-                fontWeight: 'bold',
-              },
-              contentStyle: {
-                backgroundColor: Colors.background,
-              },
-            }}
-          >
-            <Stack.Screen name="index" options={{ headerShown: false }} />
-            <Stack.Screen name="login" options={{ headerShown: false }} />
-            <Stack.Screen name="review" options={{ headerShown: false }} />
-            <Stack.Screen name="create" options={{ headerShown: false, presentation: 'modal' }} />
-          </Stack>
-        </MemoProvider>
-      </AuthProvider>
-    </SafeAreaProvider>
+    <View style={{ flex: 1, backgroundColor: Colors.background }}>
+      <SafeAreaProvider>
+        <AuthProvider>
+          <MemoProvider>
+            <StatusBar style="dark" />
+            <Stack
+              screenOptions={{
+                headerStyle: {
+                  backgroundColor: Colors.background,
+                },
+                headerTintColor: Colors.foreground,
+                headerTitleStyle: {
+                  fontWeight: 'bold',
+                },
+                contentStyle: {
+                  backgroundColor: Colors.background,
+                },
+              }}
+            >
+              <Stack.Screen name="index" options={{ headerShown: false }} />
+              <Stack.Screen name="login" options={{ headerShown: false }} />
+              <Stack.Screen name="review" options={{ headerShown: false }} />
+              <Stack.Screen name="create" options={{ headerShown: false, presentation: 'modal' }} />
+            </Stack>
+          </MemoProvider>
+        </AuthProvider>
+      </SafeAreaProvider>
+    </View>
   );
 }

--- a/shabelingo-mobile/app/collections/index.tsx
+++ b/shabelingo-mobile/app/collections/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity, Alert, Modal, TextInput, ActivityIndicator, SafeAreaView, Platform, TouchableWithoutFeedback, Keyboard, KeyboardAvoidingView } from 'react-native';
-import { useRouter } from 'expo-router';
-import { Plus, Trash2, Folder, ChevronRight, Share2, Play } from 'lucide-react-native';
+import { useRouter, Stack } from 'expo-router';
+import { Plus, Trash2, Folder, ChevronRight, Share2, Play, ChevronLeft } from 'lucide-react-native';
 import { useAuth } from '../../context/AuthContext';
 import { Collection } from '../../types';
 import { subscribeCollections, createCollection, deleteCollection } from '../../lib/collections';
@@ -97,15 +97,23 @@ export default function CollectionsScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.header}>
-        <Text style={styles.title}>Collections</Text>
-        <Button 
-          variant="ghost" 
-          size="icon" 
-          icon={<Plus size={24} color={Colors.primary} />} 
-          onPress={() => setModalVisible(true)} 
-        />
-      </View>
+      <Stack.Screen 
+        options={{
+          title: 'Collections',
+          headerLargeTitle: true,
+          headerShadowVisible: false,
+          headerStyle: { backgroundColor: Colors.background },
+          headerBackTitle: '', // Hide back button text
+          headerRight: () => (
+             <Button 
+               variant="ghost" 
+               size="icon" 
+               icon={<Plus size={24} color={Colors.primary} />} 
+               onPress={() => setModalVisible(true)} 
+             />
+          ),
+        }} 
+      />
 
       {loading ? (
         <View style={styles.center}>
@@ -185,15 +193,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: Colors.background,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: Layout.padding,
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.border,
   },
   title: {
     fontSize: 24,


### PR DESCRIPTION
- コレクション一覧画面と詳細画面のヘッダーを標準の `Stack.Screen` に統一し、レイアウトの一貫性を確保しました。
- 自前ヘッダーを廃止し、`SafeAreaView` を適切に使用することで、画面遷移時のレイアウトズレを解消しました。
- 戻るボタンのラベル（`< index`, `< Collections`）を非表示にし、ヘッダーをよりシンプルでスタイリッシュなデザイン（影なし、透過背景）に変更しました。
- TypeScriptのエラーとなっていた、存在しない `headerBackTitleVisible` プロパティを修正しました。
- 詳細画面のデータ読み込み中に、デフォルトのヘッダータイトル（`collections/[id]`）が一瞬表示される問題を修正しました。